### PR TITLE
Command changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ hs_err_pid*
 .idea/
 *.iml
 target/
+
+# gradle
+.gradle/
+build/

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Please note that if you want a chance maximum other than 100 right now, you cann
 
 # Commands
 - `/crate` - does nothing
-- `/crate <crate id>` - Gives you a placeable crate block. Will look weird but trust me, it's the right thing.
-- `/crate <crate id> key [player]` - Give you, or someone you choose, a crate key.
+- `/crate chest <crate id> [quantity]` - Gives you a placeable crate block. Will look weird but trust me, it's the right thing.
+- `/crate key <crate id> [player] [quantity]` - Give you, or someone you choose, a crate key.
 
 Crate IDs are the values you put first inside of the crates{} in the config. So like, command in the example would be the crate id.
 

--- a/src/main/java/pw/codehusky/huskycrates/HuskyCrates.java
+++ b/src/main/java/pw/codehusky/huskycrates/HuskyCrates.java
@@ -41,7 +41,10 @@ import org.spongepowered.api.text.format.TextColors;
 import org.spongepowered.api.text.serializer.TextSerializers;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
+import pw.codehusky.huskycrates.commands.Chest;
 import pw.codehusky.huskycrates.commands.Crate;
+import pw.codehusky.huskycrates.commands.Key;
+import pw.codehusky.huskycrates.commands.elements.CrateElement;
 import pw.codehusky.huskycrates.crate.CrateUtilities;
 import pw.codehusky.huskycrates.crate.VirtualCrate;
 
@@ -56,6 +59,7 @@ public class HuskyCrates {
     @Inject
     public Logger logger;
 
+
     @Inject
     private PluginContainer pC;
     @Inject
@@ -67,18 +71,52 @@ public class HuskyCrates {
     public CrateUtilities crateUtilities = new CrateUtilities(this);
     public String huskyCrateIdentifier = "☼1☼2☼3HUSKYCRATE-";
     public String armorStandIdentifier = "ABABABAB-CDDE-0000-8374-CAAAECAAAECA";
+    public static HuskyCrates instance;
     @Listener
     public void gameInit(GamePreInitializationEvent event){
         logger.info("Let's not init VCrates here anymore. ://)");
+        instance = this;
     }
     @Listener
     public void gameStarted(GameStartedServerEvent event){
+
+
+
+        CommandSpec key = CommandSpec.builder()
+                .description(Text.of("Get a key for a specified crate "))
+                .arguments(
+                        new CrateElement(Text.of("type")),
+                        GenericArguments.playerOrSource(Text.of("player")),
+                        GenericArguments.optional(GenericArguments.integer(Text.of("quantity")))
+                )
+                .permission("huskycrates")
+                .executor(new Key())
+                .build();
+
+
+        CommandSpec chest = CommandSpec.builder()
+                .description(Text.of("Main crates command"))
+                .permission("huskycrates")
+                .arguments(
+                        new CrateElement(Text.of("type")),
+                        GenericArguments.playerOrSource(Text.of("player")),
+                        GenericArguments.optional(GenericArguments.integer(Text.of("quantity")))
+                ).executor(new Chest())
+                .build();
+
         CommandSpec crateSpec = CommandSpec.builder()
                 .description(Text.of("Main crates command"))
                 .permission("huskycrates")
-                .arguments(GenericArguments.optional(GenericArguments.string(Text.of("param1"))),GenericArguments.optional(GenericArguments.string(Text.of("param2"))),GenericArguments.optional(GenericArguments.player(Text.of("player"))))
+                .arguments(
+                        GenericArguments.optional(GenericArguments.string(Text.of("param1"))),
+                        GenericArguments.optional(GenericArguments.string(Text.of("param2"))),
+                        GenericArguments.optional(GenericArguments.player(Text.of("player")))
+                )
+                .child(key, "key")
+                .child(chest, "chest")
                 .executor(new Crate(this))
                 .build();
+
         scheduler = Sponge.getScheduler();
         genericCause = Cause.of(NamedCause.of("PluginContainer",pC));
         Sponge.getCommandManager().register(this, crateSpec, "crate");
@@ -187,5 +225,14 @@ public class HuskyCrates {
 
 
         }
+    }
+
+
+    public CrateUtilities getCrateUtilities() {
+        return crateUtilities;
+    }
+
+    public String getHuskyCrateIdentifier() {
+        return huskyCrateIdentifier;
     }
 }

--- a/src/main/java/pw/codehusky/huskycrates/commands/Chest.java
+++ b/src/main/java/pw/codehusky/huskycrates/commands/Chest.java
@@ -1,0 +1,44 @@
+package pw.codehusky.huskycrates.commands;
+
+import org.spongepowered.api.command.CommandException;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.spec.CommandExecutor;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.item.inventory.ItemStack;
+import org.spongepowered.api.text.Text;
+import pw.codehusky.huskycrates.HuskyCrates;
+import pw.codehusky.huskycrates.crate.VirtualCrate;
+
+import java.util.Optional;
+
+/**
+ * Created By KasperFranz.
+ *
+ * This CommandExecutor is used to get the crate placeable chest.
+ */
+public class Chest implements CommandExecutor {
+
+    @Override public CommandResult execute(CommandSource commandSource, CommandContext commandContext) throws CommandException {
+        String type = commandContext.<String>getOne("type").get();
+        Optional<Player> player = commandContext.getOne("player");
+        VirtualCrate virtualCrate = HuskyCrates.instance.getCrateUtilities().getVirtualCrate(type);
+        int quantity = commandContext.getOne("quantity").isPresent() ? commandContext.<Integer>getOne("quantity").get() : 1;
+        if (virtualCrate == null) {
+            HuskyCrates.instance.logger.info("Invalid crate id. Please check your config.");
+            return CommandResult.empty();
+        }
+
+        if (!player.isPresent()) {
+            commandSource.sendMessage(Text.of("You need to either specify a player or be in game"));
+            return CommandResult.empty();
+        }
+
+        ItemStack chestItemStack = virtualCrate.getCrateItem(quantity);
+        player.get().getInventory().offer(chestItemStack);
+
+        return CommandResult.success();
+
+    }
+}

--- a/src/main/java/pw/codehusky/huskycrates/commands/Key.java
+++ b/src/main/java/pw/codehusky/huskycrates/commands/Key.java
@@ -1,0 +1,48 @@
+package pw.codehusky.huskycrates.commands;
+
+import org.spongepowered.api.command.CommandException;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.spec.CommandExecutor;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.item.inventory.ItemStack;
+import org.spongepowered.api.item.inventory.transaction.InventoryTransactionResult;
+import org.spongepowered.api.text.Text;
+import pw.codehusky.huskycrates.HuskyCrates;
+import pw.codehusky.huskycrates.crate.VirtualCrate;
+
+import java.util.Optional;
+
+/**
+ * Created By KasperFranz.
+ *
+ * This CommandExecutor is used to get the crate item.
+ */
+public class Key implements CommandExecutor {
+
+    @Override public CommandResult execute(CommandSource commandSource, CommandContext commandContext) throws CommandException {
+        String type = commandContext.<String>getOne("type").get();
+        Optional<Player> player = commandContext.getOne("player");
+        VirtualCrate virtualCrate = HuskyCrates.instance.getCrateUtilities().getVirtualCrate(type);
+        int quantity = commandContext.getOne("quantity").isPresent() ? commandContext.<Integer>getOne("quantity").get() : 1;
+        if (virtualCrate == null) {
+            HuskyCrates.instance.logger.info("Invalid crate id. Please check your config.");
+            return CommandResult.empty();
+        }
+
+        if (!player.isPresent()) {
+            commandSource.sendMessage(Text.of("You need to be in game or specify a player for this command to work."));
+            return CommandResult.empty();
+        }
+
+
+        ItemStack keyItemStack = virtualCrate.getCrateKey(quantity);
+        if (!player.get().getInventory().offer(keyItemStack.copy()).getType().equals(InventoryTransactionResult.Type.SUCCESS) &&
+                !player.get().getEnderChestInventory().offer(keyItemStack.copy()).getType().equals(InventoryTransactionResult.Type.SUCCESS)) {
+            HuskyCrates.instance.logger
+                    .info("Couldn't give key to " + player.get().getName() + " because of a full inventory and enderchest");
+        }
+        return CommandResult.success();
+    }
+}

--- a/src/main/java/pw/codehusky/huskycrates/commands/elements/CrateElement.java
+++ b/src/main/java/pw/codehusky/huskycrates/commands/elements/CrateElement.java
@@ -1,0 +1,44 @@
+package pw.codehusky.huskycrates.commands.elements;
+
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.ArgumentParseException;
+import org.spongepowered.api.command.args.CommandArgs;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.args.CommandElement;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.format.TextColors;
+import pw.codehusky.huskycrates.HuskyCrates;
+
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+/**
+ * Created By KasperFranz.
+ *
+ * This CommandElement is used to get the different crate Types, so they can be tabbed when using the command.
+ */
+public class CrateElement extends CommandElement {
+
+    public CrateElement(Text key) {
+        super(key);
+    }
+
+    @Nullable
+    @Override
+    protected Object parseValue(CommandSource commandSource, CommandArgs commandArgs) throws ArgumentParseException {
+        String arg = commandArgs.next();
+        if (HuskyCrates.instance.getCrateUtilities().getCrateTypes().contains(arg)) {
+            return arg;
+        }
+        throw commandArgs.createError(Text.of(TextColors.RED, arg, " is not a valid Crate!"));
+    }
+
+    @Override
+    public List<String> complete(CommandSource commandSource, CommandArgs commandArgs, CommandContext commandContext) {
+
+        //TODO: It is here we should do some perm check :)!
+        return HuskyCrates.instance.getCrateUtilities().getCrateTypes();
+    }
+
+}

--- a/src/main/java/pw/codehusky/huskycrates/crate/CrateUtilities.java
+++ b/src/main/java/pw/codehusky/huskycrates/crate/CrateUtilities.java
@@ -159,4 +159,12 @@ public class CrateUtilities {
 
         }
     }
+
+    /***
+     * Get the different Types of crate types.
+     * @return a ArrayList of the different keys for crates.
+     */
+    public List<String> getCrateTypes() {
+        return new ArrayList<>(crateTypes.keySet());
+    }
 }

--- a/src/main/java/pw/codehusky/huskycrates/crate/VirtualCrate.java
+++ b/src/main/java/pw/codehusky/huskycrates/crate/VirtualCrate.java
@@ -8,8 +8,10 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.item.ItemType;
+import org.spongepowered.api.item.ItemTypes;
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.format.TextColors;
 import org.spongepowered.api.text.serializer.TextSerializers;
 import pw.codehusky.huskycrates.HuskyCrates;
 import pw.codehusky.huskycrates.crate.config.CrateRewardHolder;
@@ -30,10 +32,12 @@ public class VirtualCrate {
     private ArrayList<Object[]> itemSet;
     private HashMap<ItemStack, String> commandSet;
     public String displayName;
+    public String id;
     public String crateType;
     private float maxProb = 100;
     public boolean invalidCrate = false;
     public VirtualCrate(String id, ConfigurationLoader<CommentedConfigurationNode> config, CommentedConfigurationNode node){
+        this.id = id;
         displayName = node.getNode("name").getString();
         crateType = node.getNode("type").getString();
         List<? extends CommentedConfigurationNode> items = node.getNode("items").getChildrenList();
@@ -125,5 +129,39 @@ public class VirtualCrate {
             invalidCrate = true;
         }
         return new NullCrateView(plugin,plr,this);
+    }
+
+
+
+    /***
+     * Retrieve the crate item
+     * @since 0.10.2
+     * @param quantity the quantity of keys you want.
+     * @return the ItemStack with the keys.
+     */
+    public ItemStack getCrateKey(int quantity){
+        ItemStack key = ItemStack.builder()
+                .itemType(ItemTypes.NETHER_STAR)
+                .quantity(quantity)
+                .add(Keys.DISPLAY_NAME, TextSerializers.FORMATTING_CODE.deserialize(displayName + " Key")).build();
+        ArrayList<Text> itemLore = new ArrayList<>();
+        itemLore.add(Text.of(TextColors.WHITE, "A key for a ", TextSerializers.FORMATTING_CODE.deserialize(displayName), TextColors.WHITE, "."));
+        itemLore.add(Text.of(TextColors.WHITE, "crate_" + id));
+        key.offer(Keys.ITEM_LORE, itemLore);
+        return key;
+
+    }
+
+    /***
+     * Retrieve the crate chest.
+     * @since 0.10.2
+     * @param quantity the quantity of chests you want.
+     * @return the ItemStack with the chest.
+     */
+    public ItemStack getCrateItem(int quantity) {
+        return ItemStack.builder()
+                .itemType(ItemTypes.CHEST)
+                .quantity(quantity)
+                .add(Keys.DISPLAY_NAME, Text.of(HuskyCrates.instance.getHuskyCrateIdentifier() + id)).build();
     }
 }


### PR DESCRIPTION
- moved to use chest and key as subcommand instead of the previous way (the old way still works - not sure how it goes together, I would suggest removing the executor and params of the base command)
- Made new parts in the VirtualCrate to retrieve chest and keys
- Made part in CrateUtilities to retrieve the different keys for the command Element
- Added quantity to the chest and key subcommands
- If the key can't go in the inventory it is placed in the enderChest


Sidenote - I haven't had this on a server for testing (mostly regarding the new subcommands, and how it works with the old)