### PR TITLE
Fix issues with custom directory not initializing

### DIFF
--- a/src/main/java/com/codehusky/huskycrates/Registry.java
+++ b/src/main/java/com/codehusky/huskycrates/Registry.java
@@ -310,7 +310,7 @@ public class Registry {
 
         DataSource dbSource = null;
         try {
-            dbSource = Sponge.getServiceManager().provide(SqlService.class).get().getDataSource("jdbc:h2:" + HuskyCrates.instance.configDir.resolve("data"));
+            dbSource = Sponge.getServiceManager().provide(SqlService.class).get().getDataSource("jdbc:h2:./" + HuskyCrates.instance.configDir.resolve("data"));
             Connection connection = dbSource.getConnection();
             boolean cP = connection.getMetaData().getTables(null,null,"CRATELOCATIONS",null).next();
             boolean cKU = connection.getMetaData().getTables(null,null,"VALIDKEYS",null).next();


### PR DESCRIPTION
Had this issue on my server. Changed the sponge directory to plugins, and husky broke. Turns out it does not follow the latest h2 configuration. This helps with implicit directories, fix tested on my server.